### PR TITLE
use apps dev version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /nbproject/private/
 /nbproject/
+/modules
+/libraries
+/themes

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -9,6 +9,10 @@ projects[apps][type] = "module"
 projects[apps][version] = 1.x-dev
 projects[apps][subdir] = contrib
 
+projects[app_manifest][type] = "module"
+projects[app_manifest][version] = 1.0-alpha2
+projects[app_manifest][subdir] = contrib
+
 includes[panopoly] = http://drupalcode.org/project/panopoly.git/blob_plain/refs/tags/7.x-1.0-rc3:/drupal-org.make
 
 ; Pushtape

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -4,6 +4,11 @@
 core = 7.17
 api = 2
 
+
+projects[apps][type] = "module"
+projects[apps][version] = 1.x-dev
+projects[apps][subdir] = contrib
+
 includes[panopoly] = http://drupalcode.org/project/panopoly.git/blob_plain/refs/tags/7.x-1.0-rc3:/drupal-org.make
 
 ; Pushtape


### PR DESCRIPTION
we need to override apps version for library install to work. afraid thats hard if panopoly tries to apply a patch that is already comitted. might aswell add appmanifest devhelper module aswell while we do this.
http://drupal.org/node/1348814
we need to ask panopoly people why they wont switch to apps beta (or if they have another workaround we can use) 
